### PR TITLE
Add "Name" placeholder instead of leaving blank

### DIFF
--- a/Tweak.xm
+++ b/Tweak.xm
@@ -30,7 +30,7 @@
 - (UILabel *)textLabel
 {
     UILabel *o = %orig;
-    [o setText:@"    "];
+    [o setText:@"Name"];
     return o;
 }
 %end


### PR DESCRIPTION
With this pull request I've changed the placeholder text for the Settings app from "    " to "Name". This gives it a cleaner look.